### PR TITLE
Enh empty doc no ocr

### DIFF
--- a/ocr_service/api/process.py
+++ b/ocr_service/api/process.py
@@ -113,7 +113,9 @@ def process(request: Request, file: UploadFile | None = File(default=None)) -> O
     log.debug(f"Stream size: {len(stream)} bytes")
 
     ocr_skipped = bool(doc_metadata.get("ocr_skipped"))
-    code = 200 if len(output_text) > 0 or not stream or ocr_skipped else 500
+    text_length = doc_metadata.get("text_length")
+
+    code = 200 if text_length > 0 or not stream or ocr_skipped else 500
 
     response: dict[Any, Any] = {
         "result": build_response(

--- a/ocr_service/processor/converter.py
+++ b/ocr_service/processor/converter.py
@@ -378,6 +378,7 @@ class DocumentConverter:
             if settings.OPERATION_MODE == "NO_OCR":
                 ctx.output_text = self._xml_to_text(ctx)
                 ctx.metadata["pages"] = 1
+                ctx.metadata["ocr_skipped"] = True
             else:
                 self.log.info("Detected XML content; converting to PDF...")
                 ctx.pdf_stream = self._preprocess_xml_to_pdf(
@@ -400,6 +401,7 @@ class DocumentConverter:
                 self.log.info("Detected HTML content, handling via fallback, NO_OCR mode")
                 ctx.output_text = self._extract_text_fallback(ctx.stream, is_html=True)
                 ctx.metadata["pages"] = 1
+                ctx.metadata["ocr_skipped"] = True
             else:
                 self.log.info("Detected HTML content; converting to PDF via unoserver/LO")
                 ctx.pdf_stream = self._preprocess_doc(ctx.stream, file_name=ctx.file_name)
@@ -409,6 +411,7 @@ class DocumentConverter:
                 ctx.output_text = self._extract_text_fallback(ctx.stream, is_rtf=True)
                 ctx.metadata["pages"] = 1
                 ctx.metadata["content-type"] = "text/plain"
+                ctx.metadata["ocr_skipped"] = True
             else:
                 ctx.pdf_stream = self._preprocess_doc(ctx.stream, file_name=ctx.file_name)
 
@@ -422,6 +425,7 @@ class DocumentConverter:
             ctx.output_text = ctx.stream.decode("utf-8", "ignore")
             ctx.metadata["pages"] = 1
             ctx.metadata["content-type"] = "text/plain"
+            ctx.metadata["ocr_skipped"] = True
 
         else:
             self.log.info("Unknown file type; attempting to convert to PDF via unoserver/LO")

--- a/ocr_service/processor/processor.py
+++ b/ocr_service/processor/processor.py
@@ -87,7 +87,7 @@ class Processor:
             end_time = time.time()
             elapsed_time = float(round(float(end_time - start_time), 4))
             doc_metadata["elapsed_time"] = elapsed_time
-
+            doc_metadata["text_length"] = len(output_text)
             self.log.info("Finished processing file: " + file_name + " | Elapsed time: " + str(elapsed_time)
                           + " seconds")
         except Exception:

--- a/ocr_service/utils/utils.py
+++ b/ocr_service/utils/utils.py
@@ -195,7 +195,8 @@ def is_file_content_plain_text(stream: bytes, threshold: float = 0.95) -> bool:
 
     # If it can't be decoded as UTF-8 at all, treat as binary
     try:
-        sample.decode("utf-8")
+        # old documents have \x95 and \x96 characters. Use replace
+        sample.decode("utf-8", errors="replace")
     except UnicodeDecodeError:
         return False
 


### PR DESCRIPTION
added the no ocr flag in a few extra conversion pathways for consistency so that empty documents don't return errors.
added a text_length entry in the metadata so that nifi can filter without having to re-evaluate the text length